### PR TITLE
fix drawBorder so it would not overwrite misses

### DIFF
--- a/border.go
+++ b/border.go
@@ -35,7 +35,8 @@ func (b *Board) drawBorder(p point, position pos) {
 			}
 		}
 
-		if b.b[dx][dy] != Ship && b.b[dx][dy] != Hit {
+		prev := b.b[dx][dy]
+		if !(prev == Ship || prev == Hit || prev == Miss) { // don't overwrite already marked
 			b.b[dx][dy] = Border
 		}
 	}


### PR DESCRIPTION
Using `CreateBorder` method overwrites misses, making it impossible to distinguish manually marked coordinates from automatically marked border. This change fixes it.