### PR TITLE
refactor documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,2 @@
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
 # Warships-LightGUI
 
+Warships-LightGUI provides an easy to use graphical user interface 
+for the `Warships Online` game.
+
 <img src="doc/warships.png" width=50%>
 
-You can easily create an ascii-based GUI for the 'Warships Online' game. This is a very simple solution, suggested for beginners. If you want to create a more sophisticated GUI, please use: 
-- http://github.com/grupawp/warships-gui
+This package is suggested for beginners. If you want a more sophisticated
+GUI, please check out the `Warships-GUI` package:
+http://github.com/grupawp/warships-gui
 
+## Installation
+
+```
+go get github.com/grupawp/warships-lightgui
+```
 
 ## Quick Start
 
-To initialize the *board* use the **New()** method. **NewConfig()** will load the default layout.
+To initialize the *board* use the **New()** method. **NewConfig()** will 
+load the default configuration.
 
 ```go
-board := gui.New(
-    gui.NewConfig()
-)
-
+board := gui.New(gui.NewConfig())
 board.Display()
 ```
 
-It's possible to customize layout of the board. Use the **ConfigParams()** method and just after it put any parameters as in the example below. 
-
-**NewConfig()** at the end of sequence, generates a new configuration that you can use as a parameter to **New()**
-
-
+To customize colours and characters used to indicate ships, misses, etc, 
+use methods available on the `config` instance. 
 
 ```go
 board := gui.New(
@@ -32,108 +36,8 @@ board := gui.New(
         BorderColor(color.BgRed).
         RulerTextColor(color.BgYellow).
         NewConfig())
-
 board.Display()
 ```
 
-
-## Available Options
-
-### Marking a ship component as hit
-- HitColor(color)
-- HitChar(byte)
-
-### Missed shot
-- MissColor(color)
-- MissChar(byte)
-
-### Ship component
-- ShipColor(color)
-- ShipChar(byte)
-
-### Border around the sunken ship
-- BorderColor(color)
-- BorderChar(byte)
-
-### Empty element on the board
-- EmptyColor(color)
-- EmptyChar(byte)
-
-### Horizontal and vertical ruler text color
-- RulerTextColor(color)
-
-## Methods and constants
-
-- **pos** type is defined as below. 
-
-```go
-const (
-	Left
-	Right
-)
-```
-
-    - 'Left' means the board on the left side of the screen, e.g. a board with your own ships.
-    - 'Right' means the board on the other side (your opponent's ships)
-
-
-
-- **state** type definition:
-```go
-const (
-	Empty
-	Hit
-	Miss
-	Ship
-	Border
-)
-```
-
-### After create a *board* object, you can use the following methods:
-
-```go
-func (board) CreateBorder(p pos, coord string) {
-```
-
-- **CreateBorder()** creates a border around (sunken) ship
-    - p: Left or Right board
-    - coord: any element of the ship
-
-
-```go
-func (board) HitOrMiss(p pos, coord string) state
-```
-
-- **HitOrMiss()** checks if a state at the coord is a Ship, then change to Hit and return Hit. Else (not a Ship), change to Miss and return Miss
-
-```go
-func (board) Set(p pos, coord string, s state)
-```
-
-- **Set()** changes the state at the selected coordinates 
-    - p: Left or Right board
-    - coord: "A7", "C3" etc.
-    - s: Hit, Ship etc.
-
-```go
-func (board) Export(p pos) []string 
-```
-
-- **Export()** exports the board configuration to a format accepted by the game server
-    - p: Left or Right board
-
-```go
-func (board) Import(coords []string) 
-```
-
-- **Import()** imports the board from array of coord
-    - coords: []string{"A4", "C1"} etc.
-
-```go
-func (board) Display()
-```
-
-- **Display()** displays both boards (left and right)
-
-
-
+## Documentation
+https://pkg.go.dev/github.com/grupawp/warships-lightgui

--- a/board_test.go
+++ b/board_test.go
@@ -1,0 +1,53 @@
+package board
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+func ExampleBoard_Import() {
+	board := New(NewConfig())
+	coords := []string{"A1", "A2", "A3"}
+	board.Import(coords)
+}
+
+func ExampleBoard_Export() {
+	board := New(NewConfig())
+	coords := []string{"A1", "A2", "A3"}
+	board.Import(coords)
+	exported := board.Export(Left)
+	fmt.Println(exported)
+	// Output: [A3 A2 A1]
+}
+
+func ExampleBoard_Set_enemy() {
+	board := New(NewConfig())
+	board.Set(Right, "C3", Hit)
+}
+
+func ExampleBoard_Set_player() {
+	board := New(NewConfig())
+	board.Set(Left, "A1", Ship)
+}
+
+func ExampleBoard_HitOrMiss() {
+	board := New(NewConfig())
+	board.Set(Left, "A1", Ship)
+	board.HitOrMiss(Left, "A1")
+}
+
+func ExampleNew_simple() {
+	cfg := NewConfig()
+	New(cfg)
+}
+
+func ExampleNew_advanced() {
+	New(
+		NewConfig().
+			HitChar('#').
+			HitColor(color.FgRed).
+			BorderColor(color.BgRed).
+			RulerTextColor(color.BgYellow).
+			NewConfig())
+}

--- a/border.go
+++ b/border.go
@@ -1,5 +1,7 @@
 package board
 
+import "log"
+
 type point struct {
 	x, y int
 }
@@ -83,8 +85,15 @@ func (b *Board) searchElement(x, y int, points *[]point, p pos) {
 	}
 }
 
+// CreateBorder creates a border around a (sunken) ship, to indicate
+// which coordinates cannot contain a ship segment and can be safely
+// ignored.
 func (b *Board) CreateBorder(p pos, coord string) {
-	x, y := b.stringCoordToInt(coord)
+	x, y, err := b.stringCoordToInt(coord)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
 	if p == Right {
 		x = x + boardWidth + delimiter

--- a/config.go
+++ b/config.go
@@ -3,18 +3,18 @@ package board
 import "github.com/fatih/color"
 
 type customizer interface {
-	EmptyColor(color.Attribute) customizer
-	EmptyChar(byte) customizer
+	NewConfig() *config
 	RulerTextColor(color.Attribute) customizer
+	BorderChar(byte) customizer
+	BorderColor(color.Attribute) customizer
+	EmptyChar(byte) customizer
+	EmptyColor(color.Attribute) customizer
 	HitChar(byte) customizer
 	HitColor(color.Attribute) customizer
 	MissChar(byte) customizer
 	MissColor(color.Attribute) customizer
 	ShipChar(byte) customizer
 	ShipColor(color.Attribute) customizer
-	BorderChar(byte) customizer
-	BorderColor(color.Attribute) customizer
-	NewConfig() *config
 }
 
 type config struct {
@@ -31,65 +31,78 @@ type config struct {
 	borderColor    color.Attribute
 }
 
+// NewConfig returns a new config.
 func (c *config) NewConfig() *config {
 	return c
 }
 
-func (c *config) EmptyColor(col color.Attribute) customizer {
-	c.emptyColor = col
-	return c
-}
-
-func (c *config) ShipColor(col color.Attribute) customizer {
-	c.shipColor = col
-	return c
-}
-
-func (c *config) ShipChar(n byte) customizer {
-	c.shipChar = n
-	return c
-}
-
-func (c *config) EmptyChar(n byte) customizer {
-	c.emptyChar = n
-	return c
-}
-
-func (c *config) BorderChar(n byte) customizer {
-	c.borderChar = n
-	return c
-}
-
-func (c *config) BorderColor(col color.Attribute) customizer {
-	c.borderColor = col
-	return c
-}
-
-func (c *config) HitChar(n byte) customizer {
-	c.hitChar = n
-	return c
-}
-
-func (c *config) HitColor(col color.Attribute) customizer {
-	c.hitColor = col
-	return c
-}
-
-func (c *config) MissChar(n byte) customizer {
-	c.missChar = n
-	return c
-}
-
-func (c *config) MissColor(col color.Attribute) customizer {
-	c.missColor = col
-	return c
-}
-
+// RulerTextColor sets the color of the ruler text.
 func (c *config) RulerTextColor(col color.Attribute) customizer {
 	c.rulerTextColor = col
 	return c
 }
 
+// BorderChar sets the character used to represent a border around sunken ships.
+func (c *config) BorderChar(n byte) customizer {
+	c.borderChar = n
+	return c
+}
+
+// BorderColor sets the color of a border around sunken ships.
+func (c *config) BorderColor(col color.Attribute) customizer {
+	c.borderColor = col
+	return c
+}
+
+// EmptyChar sets the character used to represent empty coordinates.
+func (c *config) EmptyChar(n byte) customizer {
+	c.emptyChar = n
+	return c
+}
+
+// EmptyColor sets the color of empty coordinates.
+func (c *config) EmptyColor(col color.Attribute) customizer {
+	c.emptyColor = col
+	return c
+}
+
+// HitChar sets the character used to represent hits.
+func (c *config) HitChar(n byte) customizer {
+	c.hitChar = n
+	return c
+}
+
+// HitColor sets the color of coordinates containing hits.
+func (c *config) HitColor(col color.Attribute) customizer {
+	c.hitColor = col
+	return c
+}
+
+// MissChar sets the character used to represent misses.
+func (c *config) MissChar(n byte) customizer {
+	c.missChar = n
+	return c
+}
+
+// MissColor sets the color of coordinates containing misses.
+func (c *config) MissColor(col color.Attribute) customizer {
+	c.missColor = col
+	return c
+}
+
+// ShipColor sets the color of coordinates containing ship segments.
+func (c *config) ShipColor(col color.Attribute) customizer {
+	c.shipColor = col
+	return c
+}
+
+// ShipChar sets the character used to represent ship segments.
+func (c *config) ShipChar(n byte) customizer {
+	c.shipChar = n
+	return c
+}
+
+// NewConfig returns a new config with default values.
 func NewConfig() *config {
 	return &config{
 		emptyChar:      ' ',
@@ -106,6 +119,11 @@ func NewConfig() *config {
 	}
 }
 
+/*
+ConfigParams returns a new config with default values.
+
+Deprecated: use NewConfig instead.
+*/
 func ConfigParams() customizer {
 	return NewConfig()
 }

--- a/display.go
+++ b/display.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fatih/color"
 )
 
+// Display clears the terminal and prints the board.
 func (b *Board) Display() {
 	const (
 		clearScreen = "\033[H\033[2J"


### PR DESCRIPTION
Przerobiłem dokumentację, by zamiast w pliku `README.md`, znajdowała się w docstringach, dzięki czemu będzie dostępna [tutaj](https://pkg.go.dev/github.com/grupawp/warships-lightgui).

Ma to na celu przyzwyczajenie studentów do używania dokumentacji na pkg.go.dev, co jest standardem bibliotek w języku Go.

Przy okazji zmodyfikowałem funkcję `stringCoordToInt` oraz jej użycia, by w przypadku podania nieprawidłowych współrzędnych biblioteka nic nie robiła, zamiast modyfikować po cichu (0, 0). Publiczny interfejs biblioteki pozostał bez zmian.