### PR TITLE
change public interface

### DIFF
--- a/board_test.go
+++ b/board_test.go
@@ -9,13 +9,16 @@ import (
 func ExampleBoard_Import() {
 	board := New(NewConfig())
 	coords := []string{"A1", "A2", "A3"}
-	board.Import(coords)
+	err := board.Import(coords)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func ExampleBoard_Export() {
 	board := New(NewConfig())
 	coords := []string{"A1", "A2", "A3"}
-	board.Import(coords)
+	_ = board.Import(coords)
 	exported := board.Export(Left)
 	fmt.Println(exported)
 	// Output: [A3 A2 A1]
@@ -23,18 +26,27 @@ func ExampleBoard_Export() {
 
 func ExampleBoard_Set_enemy() {
 	board := New(NewConfig())
-	board.Set(Right, "C3", Hit)
+	err := board.Set(Right, "C3", Hit)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func ExampleBoard_Set_player() {
 	board := New(NewConfig())
-	board.Set(Left, "A1", Ship)
+	err := board.Set(Left, "A1", Ship)
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func ExampleBoard_HitOrMiss() {
 	board := New(NewConfig())
-	board.Set(Left, "A1", Ship)
-	board.HitOrMiss(Left, "A1")
+	_ = board.Set(Left, "A1", Ship)
+	_, err := board.HitOrMiss(Left, "A1")
+	if err != nil {
+		fmt.Println(err)
+	}
 }
 
 func ExampleNew_simple() {

--- a/border.go
+++ b/border.go
@@ -39,7 +39,7 @@ func (b *Board) drawBorder(p point, position pos) {
 
 		prev := b.b[dx][dy]
 		if !(prev == Ship || prev == Hit || prev == Miss) { // don't overwrite already marked
-			b.b[dx][dy] = Border
+			b.b[dx][dy] = border
 		}
 	}
 }

--- a/display.go
+++ b/display.go
@@ -17,10 +17,10 @@ func (b *Board) Display() {
 	for y := maxY - 1; y >= 0; y-- {
 		for x := 0; x < maxX; x++ {
 			switch s := b.b[x][y]; s {
-			case Ruler:
+			case ruler:
 				c := color.New(b.c.RulerTextColor)
 				c.Printf("%2d", y+1)
-			case Empty:
+			case empty:
 				c := color.New(b.c.EmptyColor)
 				c.Printf(" %s", b.printChar(s))
 			case Hit:
@@ -32,7 +32,7 @@ func (b *Board) Display() {
 			case Miss:
 				c := color.New(b.c.MissColor)
 				c.Printf(" %s", b.printChar(s))
-			case Border:
+			case border:
 				c := color.New(b.c.BorderColor)
 				c.Printf(" %s", b.printChar(s))
 			}


### PR DESCRIPTION
Ten pull request aktualizuje publiczny interface, jako że i tak uległ on zmianie (tworzenie konfiguracji) i wymagana jest wersja v2.

Zmiany:
 - consty `empty`, `border` i `ruler` używane są wyłącznie w ramach pakietu, więc zostały zmienione na niewyeksportowane, by nie wprowadzać zamieszania, jako że nie da się ich użyć (metoda `Set` uznaje tylko `Miss`, `Ship` i `Hit`).
 - Publiczne metody `Import`, `Set` oraz `HitOrMiss` zwracają teraz błąd `ErrInvalidCoord`. Można go zignorować i wtedy nie trzeba zmieniać w żaden sposób kodu, ale nie jest już tak, że biblioteka po cichu "zjada" błędy.

Żadna z tych dwóch zmian nie wymaga modyfikacji kodu w aplikacjach studentów, chociaż dobrze byłoby, gdyby dodali sprawdzenie błędu. Ale i tak nie będą mieli tej wersji, jeśli nie dodadzą jawnie `/v2` w ścieżce importu.